### PR TITLE
修复中文文档链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![result](IMG/93ff10b42d8cc753527e50c41b8e2d72.png)
 
-[中文文档](README_CN.MD)
+[中文文档](README_CN.md)
 
 A command-line tool for separating vocal timbres
 


### PR DESCRIPTION
GitHub的内部链接是大小写敏感的